### PR TITLE
Fix division by zero if credits are already zero

### DIFF
--- a/TrueDeathPenalty/Patches/HUDManagerPatch.cs
+++ b/TrueDeathPenalty/Patches/HUDManagerPatch.cs
@@ -7,22 +7,22 @@ namespace TrueDeathPenalty.Patches;
 public class HUDManagerPatch
 {
     private static int prevGroupCredits;
-    
+
     [HarmonyPatch("ApplyPenalty")]
     [HarmonyPrefix]
     public static void SavePreviousGroupCredits(Terminal ___terminalScript)
     {
         prevGroupCredits = ___terminalScript.groupCredits;
     }
-    
+
     [HarmonyPatch("ApplyPenalty")]
     [HarmonyPostfix]
     // ReSharper disable InconsistentNaming
     public static void AdjustPenaltyTextPatch(int playersDead, int bodiesInsured, EndOfGameStatUIElements ___statsUIElements, Terminal ___terminalScript)
     // ReSharper restore InconsistentNaming
     {
-        int penalty =  (int)Math.Round((1 - (float)___terminalScript.groupCredits / prevGroupCredits ) * 100f);
-        
+        int penalty =  (int)Math.Round((1 - (float)___terminalScript.groupCredits / Math.Max(prevGroupCredits, 1) ) * 100f);
+
         ___statsUIElements.penaltyAddition.text = $"{playersDead} casualties: -{penalty}%\n({bodiesInsured} bodies recovered)";
     }
 }


### PR DESCRIPTION
If the crew already had 0 credits when the penalty is applied, this would cause a division by zero and the penalty would be displayed as "--2147483648%".
![image](https://github.com/user-attachments/assets/b5bd6ff0-ed2c-4576-aaf4-718c33033ce6)
